### PR TITLE
Add sync after switching module strategy

### DIFF
--- a/configure_ssh_https.sh
+++ b/configure_ssh_https.sh
@@ -3,8 +3,10 @@
 case "$1" in
 "ssh")
 	k=$(cp .sshgitmodules .gitmodules 2>&1)
+
 	if [ -z "$k" ]
 	then
+		git submodule sync
 		echo "Successfully made ssh the pull strategy"
 	else 
 		echo "$k"
@@ -14,6 +16,7 @@ case "$1" in
 	k=$(cp .httpsgitmodules .gitmodules 2>&1)
 	if [ -z "$k" ]
 	then
+		git submodule sync
 		echo "Successfully made https the pull strategy"
 	else 
 		echo "$k"


### PR DESCRIPTION
After switching method, git should sync up with the new setting
configured in the .gitmodules. A reference to issue #2 as well.

(This should fix some eventual problems with #2)

[From git's website
](https://git-scm.com/docs/git-submodule)
```
sync
Synchronizes submodules' remote URL configuration setting to the value specified in .gitmodules. It will only affect those submodules which already have a URL entry in .git/config (that is the case when they are initialized or freshly added). This is useful when submodule URLs change upstream and you need to update your local repositories accordingly.

"git submodule sync" synchronizes all submodules while "git submodule sync -- A" synchronizes submodule "A" only.

If --recursive is specified, this command will recurse into the registered submodules, and sync any nested submodules within.
```