### PR TITLE
Split containerscript into smaller pieces

### DIFF
--- a/containers.sh
+++ b/containers.sh
@@ -1,4 +1,9 @@
 #!/bin/bash
+if [ "$EUID" -eq 0 ]
+then
+    echo "Please don't run the script as root!"
+    echo "Remove sudo/exit root user mode."
+fi
 start=$SECONDS
 
 RED=$(tput setaf 1)


### PR DESCRIPTION

With this PR you're able to 

`./containerscript start cassandra `

` ./containerscript start cass `

` ./containerscript start cdr `

` ./containerscript start all `

And of course

` ./containerscript start `

Also, the wait for cqlsh to be up and running is moved to CDRGen-function. This adds a bit of speed up since graphite is not depending on cassandra.